### PR TITLE
Update siteConfig to use Tomcat 10.1

### DIFF
--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -232,7 +232,7 @@ resource web 'Microsoft.Web/sites@2022-09-01' = {
   tags: {'azd-service-name': 'web'}
   properties: {
     siteConfig: {
-      linuxFxVersion: 'TOMCAT|10.0-java17'
+      linuxFxVersion: 'TOMCAT|10.1-java17'
       vnetRouteAllEnabled: true
       ftpsState: 'Disabled'
     }


### PR DESCRIPTION
## Purpose

* Update the version of Tomcat to 10.1

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe:
```

## How to Test

Run the same steps as on the README.md file

## What to Check

In the Kudu/SCM site, you can run the following command to confirm the site is actually running Tomcat 10.1 (Tomcat 10.1.16 in the output):

```
# /usr/local/tomcat/bin/version.sh 
Using CATALINA_BASE:   /usr/local/tomcat
Using CATALINA_HOME:   /usr/local/tomcat
Using CATALINA_TMPDIR: /usr/local/tomcat/temp
Using JRE_HOME:        /usr/lib/jdk
Using CLASSPATH:       /usr/local/tomcat/lib/servlet-api.jar:/usr/local/tomcat/lib/azure.appservice.jar:/usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
Using CATALINA_OPTS:   
Picked up JAVA_TOOL_OPTIONS: -Xmx1150M -Djava.net.preferIPv4Stack=true 
OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
Server version: Apache Tomcat/10.1.16
Server built:   Nov 10 2023 16:17:33 UTC
Server number:  10.1.16.0
OS Name:        Linux
OS Version:     5.15.138.1-4.cm2
Architecture:   amd64
JVM Version:    17.0.10+7-LTS
JVM Vendor:     Microsoft
```

## Other Information
<!-- Add any other helpful information that may be needed here. -->