### PR TITLE
Fix Codespaces container build and post-action redirects (starter-no-infra)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,6 @@
-FROM mcr.microsoft.com/devcontainers/java:1-17-bullseye
+FROM mcr.microsoft.com/devcontainers/java:25-bookworm
 
-# Install MySQL command-line client -- see https://dev.mysql.com/doc/refman/8.0/en/mysql.html
-RUN apt-get update && apt-get install -y gnupg lsb-release inetutils-tools \
-  && wget https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb \
-  && DEBIAN_FRONTEND=noninteractive dpkg -i mysql-apt-config_0.8.29-1_all.deb \
-  && apt-get update \
-  && apt install -y mysql-client
+# Install a MySQL-compatible command-line client from Debian repos to avoid external GPG key issues.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends inetutils-tools default-mysql-client \
+  && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
 		},
 		"ghcr.io/azure/azure-dev/azd:latest": {},
 		"ghcr.io/devcontainers/features/azure-cli:1": {}
-	},
+	}
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": []
@@ -23,12 +23,7 @@
 	// "postCreateCommand": "java -version",
 
 	// Configure tool-specific properties.
-	"customizations": {
-		"vscode": {
-		"extensions": [
-		  "github.copilot"
-		]}
-	}
+	// "customizations": {},
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"

--- a/src/main/java/com/microsoft/azure/appservice/examples/tomcatmysql/CreateServlet.java
+++ b/src/main/java/com/microsoft/azure/appservice/examples/tomcatmysql/CreateServlet.java
@@ -44,11 +44,11 @@ public class CreateServlet extends HttpServlet  {
             em.close();
         }
 
-        String path = req.getContextPath();
-        if(path != "") {
-            resp.sendRedirect(path);
-        } else {
-            resp.sendRedirect("/");
-        }
+        // Redirect back to the task list using a relative URL so the browser resolves it
+        // against its own address. Redirecting to an absolute path like "/" makes the
+        // servlet container build an absolute URL (e.g. http://localhost/) from the request
+        // Host header, which breaks behind a proxy such as GitHub Codespaces port forwarding.
+        resp.setStatus(HttpServletResponse.SC_SEE_OTHER);
+        resp.setHeader("Location", ".");
     }
 }

--- a/src/main/java/com/microsoft/azure/appservice/examples/tomcatmysql/DeleteServlet.java
+++ b/src/main/java/com/microsoft/azure/appservice/examples/tomcatmysql/DeleteServlet.java
@@ -45,11 +45,11 @@ public class DeleteServlet extends HttpServlet {
             em.close();
         }
 
-        String path = req.getContextPath();
-        if(path != "") {
-            resp.sendRedirect(path);
-        } else {
-            resp.sendRedirect("/");
-        }
+        // Redirect back to the task list using a relative URL so the browser resolves it
+        // against its own address. Redirecting to an absolute path like "/" makes the
+        // servlet container build an absolute URL (e.g. http://localhost/) from the request
+        // Host header, which breaks behind a proxy such as GitHub Codespaces port forwarding.
+        resp.setStatus(HttpServletResponse.SC_SEE_OTHER);
+        resp.setHeader("Location", ".");
     }
 }


### PR DESCRIPTION
## What this does

Ports the non-infra fixes from #6 onto the `starter-no-infra` branch (the tutorial starting point, which has no `infra/` or `azure.yaml`).

### Dev container
- **`Dockerfile`:** base image `java:1-17-bullseye` → `java:25-bookworm`; install `default-mysql-client` from Debian repos instead of the MySQL APT config. The old approach failed the Codespace build on a broken external Yarn GPG key, blocking the tutorial at step one.
- **`devcontainer.json`:** remove trailing comma after `features` and drop the unused `customizations` block.

### App code
- **`CreateServlet` / `DeleteServlet`:** redirect after POST with a **relative** URL (`Location: .`) instead of `sendRedirect("/")`. Behind a proxy such as GitHub Codespaces port forwarding, the container sees `Host: localhost` and builds an absolute `http://localhost/` redirect the browser can't reach. The relative redirect keeps the browser on the forwarded host and works on both Jetty (local) and Tomcat (App Service).

## Notes
- Infra-related changes from #6 (Azure Managed Redis, `TOMCAT|11.0-java25`, `WEBSITE_AUTOCONFIGURE_DATABASE=true`) are intentionally **not** included here — this branch has no infra files; those steps belong in the tutorial article's `az` CLI commands.
- `mvn compile` passes.