### PR TITLE
Align all log4j artifacts to 2.25.3 (supersedes #5)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <log4j.version>2.25.3</log4j.version>
     </properties>
 
     <dependencies>
@@ -60,18 +61,18 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.25.3</version>
+            <version>${log4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.22.1</version>
+            <version>${log4j.version}</version>
         </dependency>
         <!-- new -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-jul</artifactId>
-            <version>2.22.1</version>
+            <version>${log4j.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.22.1</version>
+            <version>2.25.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Supersedes #5.

Dependabot PR #5 bumped only `log4j-core` (2.22.1 → 2.25.3) and left `log4j-api` and `log4j-jul` at 2.22.1, leaving the three log4j artifacts at mismatched versions.

This PR introduces a shared `log4j.version` property (`2.25.3`) and references it from all three dependencies so they always move together.

### Changes
- Add `<log4j.version>2.25.3</log4j.version>` property
- `log4j-core`, `log4j-api`, `log4j-jul` all use `${log4j.version}`

### Validation
- All three artifacts confirmed published at 2.25.3 on Maven Central (HTTP 200)
- `pom.xml` is well-formed XML
- Source uses only stable public log4j API (`LogManager.getLogger`, `logger.info`) and a standard `log4j2.properties` config — no breaking changes across 2.22 → 2.25