### PR TITLE
Upgrade to Jetty EE10 Maven plugin and update logging configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,9 +86,9 @@
                 <version>3.4.0</version>
             </plugin>
             <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-maven-plugin</artifactId>
-                <version>11.0.20</version>
+                <groupId>org.eclipse.jetty.ee10</groupId>
+                <artifactId>jetty-ee10-maven-plugin</artifactId>
+                <version>12.1.11</version>
                 <configuration>
                     <webApp>
                         <contextPath>/</contextPath>

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -8,7 +8,14 @@ appender.console.layout.pattern = %m%n
 rootLogger.level = info
 rootLogger.appenderRef.stdout.ref = STDOUT
 
-log4j.logger.org.hibernate.SQL=debug
-log4j.logger.org.hibernate.type=trace
-log4j.logger.org.hibernate.orm.jdbc.bind=trace
-log4j.logger.org.hibernate.orm.jdbc.extract=trace
+logger.hibernateSql.name = org.hibernate.SQL
+logger.hibernateSql.level = debug
+
+logger.hibernateType.name = org.hibernate.type
+logger.hibernateType.level = trace
+
+logger.hibernateJdbcBind.name = org.hibernate.orm.jdbc.bind
+logger.hibernateJdbcBind.level = trace
+
+logger.hibernateJdbcExtract.name = org.hibernate.orm.jdbc.extract
+logger.hibernateJdbcExtract.level = trace

--- a/src/main/webapp/WEB-INF/jetty-env.xml
+++ b/src/main/webapp/WEB-INF/jetty-env.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
-<Configure id='wac' class="org.eclipse.jetty.webapp.WebAppContext">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure/configure_10_0.dtd">
+<Configure id='wac' class="org.eclipse.jetty.ee10.webapp.WebAppContext">
   <New id="mysqlds" class="org.eclipse.jetty.plus.jndi.Resource">
     <Arg></Arg>
     <Arg>jdbc/MYSQLDS</Arg>


### PR DESCRIPTION
## Summary
- migrate Maven Jetty plugin from `org.eclipse.jetty:jetty-maven-plugin:11.0.20` to `org.eclipse.jetty.ee10:jetty-ee10-maven-plugin:12.1.11`
- update Jetty webapp context class in `jetty-env.xml` to EE10 package namespace
- switch log4j2 Hibernate logger entries to Log4j2 properties syntax

## Why
These changes align local runtime and servlet stack with EE10-compatible Jetty 12 and ensure the Hibernate logger configuration is correctly applied by Log4j2.

## Validation
- `azd up` completed successfully in this environment
- application deployment flow now works end-to-end