### PR TITLE
Escape task names to prevent stored XSS

### DIFF
--- a/src/main/webapp/WEB-INF/views/tasksPage.jsp
+++ b/src/main/webapp/WEB-INF/views/tasksPage.jsp
@@ -59,7 +59,7 @@
                             <tbody>
                                 <c:forEach items="${taskRecords}" var="record">  
                                     <tr>
-                                        <td class="table-text"><div>${record.getName()}</div></td>
+                                        <td class="table-text"><div><c:out value="${record.getName()}"/></div></td>
                                         <!-- Task Delete Button -->
                                         <td>
                                             <form action="delete" method="post">


### PR DESCRIPTION
## Summary

- render persisted task names with JSTL `<c:out>` so HTML metacharacters are escaped
- prevent stored XSS without changing input handling, persistence, dependencies, or tutorial steps
- preserve existing task text and CRUD behavior

## Validation

- `mvn package`
- verified `target/ROOT.war` contains the escaped output sink
- deployed to Azure App Service using the documented `azd deploy` workflow
- verified normal task create/read/delete behavior against Azure Database for MySQL
- verified an `<img onerror>` payload renders encoded, with no raw executable tag
- removed all test records after validation

Addresses CWE-79 reported by Project Glasswing.