### PR TITLE
Escape task names in tutorial starter branch

### DIFF
--- a/src/main/webapp/WEB-INF/views/tasksPage.jsp
+++ b/src/main/webapp/WEB-INF/views/tasksPage.jsp
@@ -59,7 +59,7 @@
                             <tbody>
                                 <c:forEach items="${taskRecords}" var="record">  
                                     <tr>
-                                        <td class="table-text"><div>${record.getName()}</div></td>
+                                        <td class="table-text"><div><c:out value="${record.getName()}"/></div></td>
                                         <!-- Task Delete Button -->
                                         <td>
                                             <form action="delete" method="post">


### PR DESCRIPTION
## Summary

- mirror the stored-XSS fix from `main` in the branch used by the Microsoft Learn tutorial
- render persisted task names with JSTL `<c:out>` so HTML metacharacters are escaped
- keep the starter sample, dependencies, and tutorial workflow unchanged

## Validation

- `mvn package`
- verified `target/ROOT.war` contains the escaped output sink
- `git diff --check` against `origin/starter-no-infra`

Addresses CWE-79 reported by Project Glasswing.